### PR TITLE
README link broken solved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 If you are attending the course all the course materials and preparation
 instructions are
-[here](https://philosopher-analyst.netlify.app/collection/nhsr-intro/prework/).
+[here](https://philosopher-analyst.netlify.app/intro-r/nhsr-intro/prework/).
 
 ## Are you wanting to update or use the slide code?
 


### PR DESCRIPTION
## This PR closes the following issue:
closes #72 

## Changes made:
- Broken link is replaced by `https://philosopher-analyst.netlify.app/intro-r/nhsr-intro/prework/` link.