### PR TITLE
<br> tag removed from slides.

### DIFF
--- a/02-workshop_projects.Rmd
+++ b/02-workshop_projects.Rmd
@@ -63,41 +63,41 @@ class: title-slide, left, bottom
 # Working Directory
 
 If you tell R/R Studio to look for a file, or save a plot, it will (by default) look in a place called the working
-directory (wd) </br>
+directory (wd)   
 
-</br> <img class="center" src="img/session02/working-directory.PNG"/>
+ <img class="center" src="img/session02/working-directory.PNG"/>  
 
-</br> You can (usually) see your working directory path at the top of the console panel...</br>
+ You can (usually) see your working directory path at the top of the console panel...  
 
-</br> ... it often defaults to the "Documents" folder. </br>
+ ... it often defaults to the "Documents" folder.   
 
-</br> This example is ~/workshop-r/ and ~ is in Documents
+ This example is ~/workshop-r/ and ~ is in Documents  
 
 ---
 
 # Browsing in RStudio
 
-If you click the arrow next to the file pathway ~/workshop-r/
+If you click the arrow next to the file pathway ~/workshop-r/  
 
-</br> <img src="img/session02/working-directory.PNG"/>
+ <img src="img/session02/working-directory.PNG"/>  
 
-it will return you to the working directory and you can see all the files in that folder:
+it will return you to the working directory and you can see all the files in that folder:  
 
-</br> <img class="center" src="img/session02/wd-files.PNG"/>
+ <img class="center" src="img/session02/wd-files.PNG"/>  
 
 ---
 
 class: center, middle
 
-# Organisation
+# Organisation  
 
-</br> <img class="center"src="img/session02/cognitive-load.PNG" width="15%"/>
+ <img class="center"src="img/session02/cognitive-load.PNG" width="15%"/>  
 
-</br> Sooner or later (but probably sooner) you will wish to change where files are saved (and loaded from). </br>
+ Sooner or later (but probably sooner) you will wish to change where files are saved (and loaded from).   
 
-</br> Being organised is key:</br>
+ Being organised is key:  
 
-</br> Reduces cognitive load (and frustration).
+ Reduces cognitive load (and frustration).  
 
 .footnote[Artwork by @allison_horst]
 
@@ -105,26 +105,26 @@ class: center, middle
 
 # RStudio Projects
 
-</br> make it *far easier* for you to: </br>
+make it *far easier* for you to:   
 
-</br> 1) .blue[*Organise*] files and workflow </br>
-</br> 2) .blue[*Switch*] between projects </br>
-</br> 3) .blue[*Share*] scripts / projects with others </br>
+1) .blue[*Organise*] files and workflow   
+2) .blue[*Switch*] between projects   
+3) .blue[*Share*] scripts / projects with others   
 
 
-</br> .green[(when collaborating or getting assistance)] </br>
+.green[(when collaborating or getting assistance)] 
 
-</br> Recommended for all tasks (large or small).
+Recommended for all tasks (large or small).
 
 ---
 
 # Create a project
 
-</br> File `r icons::fontawesome("arrow-right")` New Project `r icons::fontawesome("arrow-right")` New Directory `r icons::fontawesome("arrow-right")` New Project
+File `r icons::fontawesome("arrow-right")` New Project `r icons::fontawesome("arrow-right")` New Directory `r icons::fontawesome("arrow-right")` New Project
 
-</br> Name the directory "workshop-r" </br>
-</br> Create as a subdirectory somewhere useful for you </br>
-</br> Create project! </br>
+Name the directory "workshop-r"  
+Create as a subdirectory somewhere useful for you  
+Create project!  
 
 ---
 
@@ -132,10 +132,10 @@ class: center, middle
 
 Now your working directory is your project directory:
 
-</br> <img class="center" src="img/session02/workshop-r-project.PNG"/>
+<img class="center" src="img/session02/workshop-r-project.PNG"/>  
 
-</br> R will save and load files from here (by default). </br>
-</br> If starting another project, repeat this process.
+R will save and load files from here (by default).  
+If starting another project, repeat this process.  
 
 ---
 
@@ -143,9 +143,9 @@ class: middle, center
 
 # R Studio Projects
 
-Switching between projects is simple
+Switching between projects is simple  
 
-</br> <img class="center" src="img/session02/project-list.PNG"/>
+<img class="center" src="img/session02/project-list.PNG"/>  
 
 ---
 
@@ -155,9 +155,9 @@ Artwork by @allison_horst
 
 #### This work is licensed as
 
-</br> Creative Commons
-</br> Attribution
-</br> ShareAlike 4.0
-</br> International
-</br> To view a copy of this license, visit
-</br> https://creativecommons.org/licenses/by/4.0/
+ Creative Commons  
+ Attribution  
+ ShareAlike 4.0  
+ International  
+ To view a copy of this license, visit  
+ https://creativecommons.org/licenses/by/4.0/  

--- a/03-workshop_import_data.Rmd
+++ b/03-workshop_import_data.Rmd
@@ -57,21 +57,21 @@ class: title-slide, left, bottom
 
 class: center, middle
 
-# Import data to R
+# Import data to R  
 
-</br> There are R packages to import all types of data. 
-</br> In this course, we'll cover the most
-</br> common imports: 
-</br>
-</br> csvs and Excel workbooks
+ There are R packages to import all types of data.   
+ In this course, we'll cover the most  
+ common imports:   
+
+ csvs and Excel workbooks  
 
 --
 
-</br> We'd like to import the `capacity_ae.csv` file. </br> 
+ We'd like to import the `capacity_ae.csv` file.    
 
-</br> While we could write code from scratch to do this,
-</br> it's often easier to get the import wizard to do this
-</br> for you.
+ While we could write code from scratch to do this,  
+ it's often easier to get the import wizard to do this  
+ for you.  
 
 ---
 
@@ -79,17 +79,17 @@ class: center, middle
 
 # Import data to R
 
-We will use the "Import Dataset" button (but you can also click on the file itself):
+We will use the "Import Dataset" button (but you can also click on the file itself):  
 
-</br> <img class="center" src="img/session03/import-screenshot.PNG" width="80%"/>
+ <img class="center" src="img/session03/import-screenshot.PNG" width="80%"/>  
 
 ---
 
 # Import data to R
 
-We will use the "Import Dataset" button:
+We will use the "Import Dataset" button:  
 
-</br> <img class="center" src="img/session03/drop-down-import.PNG" width="60%"/>
+ <img class="center" src="img/session03/drop-down-import.PNG" width="60%"/>  
 
 ---
 
@@ -97,41 +97,41 @@ We will use the "Import Dataset" button:
 
 The package used to install csvs is {readr} which is loaded with the {tidyverse} package.
 
-Excel workbooks require the package {readxl}.
+Excel workbooks require the package {readxl}.  
 
-</br> <img class="center" src="img/session03/drop-down-import-csv.PNG" width="60%"/>
-
----
-
-# Import wizard
-
-Locate the file capacity_ae.csv
-
-</br> <img src="img/session03/wizard.PNG"/>
+ <img class="center" src="img/session03/drop-down-import-csv.PNG" width="60%"/>  
 
 ---
 
 # Import wizard
 
-</br> <img src="img/session03/capacity-ae-preview.PNG"/>
+Locate the file capacity_ae.csv  
+
+ <img src="img/session03/wizard.PNG"/>  
 
 ---
 
-# Import wizard
+# Import wizard  
 
-</br> <img src="img/session03/import-button.PNG"/>
-
----
-
-# Import wizard
-
-</br> <img src="img/session03/copy-wizard-code.PNG"/>
+ <img src="img/session03/capacity-ae-preview.PNG"/>  
 
 ---
 
-# Import wizard
+# Import wizard  
 
-</br> <img src="img/session03/copy-code-preview.PNG"/>
+ <img src="img/session03/import-button.PNG"/>  
+
+---
+
+# Import wizard  
+
+ <img src="img/session03/copy-wizard-code.PNG"/>  
+
+---
+
+# Import wizard  
+
+ <img src="img/session03/copy-code-preview.PNG"/>  
 
 ---
 
@@ -156,23 +156,23 @@ Where just one line copied:
 ]
 
 
+---  
+
+# Run code from the editor  
+
+ <img class="center" src="img/session03/run-code.PNG"/>  
+
+No need to highlight all code to run.  
+
+  Put the cursor in the line you want to run then select the button to Run or <kbd> Ctrl + Return </kbd>  
+
+
 ---
 
-# Run code from the editor
-
-</br> <img class="center" src="img/session03/run-code.PNG"/>
-
-No need to highlight all code to run.
-
-</br>  Put the cursor in the line you want to run then select the button to Run or <kbd> Ctrl + Return </kbd>
-
-
----
-
-#### This work is licensed as
-</br> Creative Commons
-</br> Attribution
-</br> ShareAlike 4.0
-</br> International
-</br> To view a copy of this license, visit
-</br> https://creativecommons.org/licenses/by/4.0/
+#### This work is licensed as  
+ Creative Commons  
+ Attribution  
+ ShareAlike 4.0  
+ International  
+ To view a copy of this license, visit  
+ https://creativecommons.org/licenses/by/4.0/  

--- a/04-workshop_ggplot2.Rmd
+++ b/04-workshop_ggplot2.Rmd
@@ -87,11 +87,11 @@ Is one of several plotting systems in R
 ---
 
 # Why is ggplot popular?
-</br>
 
-</br> 1. Well designed and supported </br> 
-</br> 2. Highly versatile </br> 
-</br> 3. Attractive graphics (with a little work)
+
+ 1. Well designed and supported    
+ 2. Highly versatile    
+ 3. Attractive graphics (with a little work)  
 
 .footnote[1. Why start with ggplot : http://varianceexplained.org/r/teach_ggplot2_to_beginners/
 2. Argument against:
@@ -99,15 +99,15 @@ https://simplystatistics.org/2016/02/11/why-i-dont-use-ggplot2/]
 
 ---
 
-[</br> <img class="center" src="img/session04/bbc-plots.PNG"/>](https://bbc.github.io/rcookbook/#left-alignright-align_text)
+[ <img class="center" src="img/session04/bbc-plots.PNG"/>](https://bbc.github.io/rcookbook/#left-alignright-align_text)
 
 ---
 
 # ggplot2
-</br>
 
-</br> ggplot2 is part of the tidyverse. </br>
-</br> So, at the top of your script type:
+
+ ggplot2 is part of the tidyverse.   
+ So, at the top of your script type:  
 
 ```{r}
 library(tidyverse)
@@ -117,15 +117,15 @@ library(tidyverse)
 
 class: inverse, middle, center
 
-## Project 1: </br>
-</br> Let’s explore a perennial </br>
-</br> challenge for the NHS:
+## Project 1:   
+ Let’s explore a perennial   
+ challenge for the NHS:  
 
 ---
 
-# Pressures in A&E
+# Pressures in A&E  
 
-</br> <img class="center" src="img/session04/demand-and-capacity.PNG"/>
+ <img class="center" src="img/session04/demand-and-capacity.PNG"/>  
 
 .footnote[
 1. [Picture 1](https://www.deviantart.com/luckymarine577/art/Animated-Ambulance-338970039) by Unknown Author is licensed under [CC BY SA NC](https://creativecommons.org/licenses/by-nc-sa/3.0/)
@@ -134,19 +134,19 @@ class: inverse, middle, center
 
 ---
 
-# Data: Capacity in A&E
-</br>
+# Data: Capacity in A&E  
 
-The dataset we loaded earlier, `capacity_ae`, shows </br>
-</br> changes in the capacity of A&E departments from </br>
-</br> 2017 to 2018
+
+The dataset we loaded earlier, `capacity_ae`, shows   
+ changes in the capacity of A&E departments from   
+ 2017 to 2018  
 
 .footnote[Closely based on datasets collected by the NHS Benchmarking Network]
 
 --
-</br>
 
-</br> The object named .green[capacity_ae] is a data frame
+
+ The object named .green[capacity_ae] is a data frame
 
 ---
 
@@ -163,10 +163,10 @@ A data frame stores tabular data:
 
 ## tibble = data frame
 
-In the tidyverse you may see the term "tibble" </br>
-</br> We’ll take "tibble" to be synonymous with "data frame"
+In the tidyverse you may see the term "tibble"   
+ We’ll take "tibble" to be synonymous with "data frame"  
 
-</br>
+
 >A tibble... is a modern reimagining of the data.frame...
 >
 >Tibbles are data.frames that are .blue[**lazy and surly**]: they do less (i.e. they don’t change variable names or types, and don’t do partial matching) and .blue[**complain more**] (e.g. when a variable does not exist). 
@@ -278,13 +278,13 @@ There are choices about the chart to use but also the details of the chart
 
 class: center, middle
 
-# Choices
+# Choices  
 
-</br> 
+ 
 
-</br> 1. What shape will represent the data points?
-</br> 
-</br> 
+ 1. What shape will represent the data points?  
+ 
+ 
 
 # .black[`r icons::icon_style(fontawesome("square-full"), scale = 2)`]
 
@@ -292,12 +292,12 @@ class: center, middle
 
 class: center, middle
 
-# Choices
-</br> 
+# Choices  
+ 
 
-</br> 1. What shape will represent the data points?
-</br>
-</br> 
+ 1. What shape will represent the data points?  
+
+ 
 
 # .black[`r icons::icon_style(fontawesome("circle", style = "solid"), scale = 2)`]
 
@@ -404,25 +404,25 @@ class: middle, center
 
 # Functions ()
 
-ggplot(), geom_point(), and aes() are functions </br> 
+ggplot(), geom_point(), and aes() are functions    
 
-</br> Running a function does something </br> 
-</br> Functions are given zero or more inputs (arguments) </br> 
-</br> Arguments of a function are separated by commas
+ Running a function does something    
+ Functions are given zero or more inputs (arguments)    
+ Arguments of a function are separated by commas  
 
 ---
 
 class: center
 
-# Functions ()
+# Functions ()  
 
-</br> You can explicitly name arguments; </br> 
+ You can explicitly name arguments;  
 
 ```{r, renv.ignore=TRUE}
 ggplot(data = capacity_ae) +
 ```
 
-</br> Or not: </br> 
+ Or not:  
 
 ```{r, renv.ignore=TRUE}
 ggplot(capacity_ae) +
@@ -430,16 +430,16 @@ ggplot(capacity_ae) +
 
 ---
 
-# Functions ()
+# Functions ()  
 
-</br> Other arguments like axes x and y are in a particular order; </br> 
+ Other arguments like axes x and y are in a particular order;  
 
 ```{r}
 ggplot(data = capacity_ae) + 
   geom_point(aes(x = dcubicles, y = dwait)) #<<
 ```
 
-</br> It is possible to write it like:
+ It is possible to write it like:
 
 ```{r}
 ggplot(data = capacity_ae) + 
@@ -454,23 +454,23 @@ But could be confusing.
 Here, we have provided **ggplot()** with one named argument
 
 .pull-right[
-.darkgrey[ggplot(.blue[**data = capacity_ae**]) + 
-</br>
+.darkgrey[ggplot(.blue[**data = capacity_ae**]) +   
+
 geom_point(.blue[**aes(x = dcubicles, y = dwait)**])]
 ]
 
 
-And given **aes()** two named arguments </br>
+And given **aes()** two named arguments   
 
-</br> Unspecified (yet required) arguments will often revert to .green[default values]
+ Unspecified (yet required) arguments will often revert to .green[default values]  
 
 ---
 
 # Shorthand
 
-Since ggplot2 knows the order of essential arguments, it is not necessary to name arguments:
+Since ggplot2 knows the order of essential arguments, it is not necessary to name arguments:  
 
-.green[data = can be omitted </br>] 
+.green[data = can be omitted ]   
 
 and 
 
@@ -489,9 +489,9 @@ ggplot(capacity_ae) +
 
 # geoms
 
-We tend to describe plots in terms of the geom used:
+We tend to describe plots in terms of the geom used:  
 
-</br> <img class="center" src="img/session04/geoms.PNG" width="80%"/>
+ <img class="center" src="img/session04/geoms.PNG" width="80%"/>  
 
 ---
 
@@ -501,13 +501,13 @@ We can display more than one geom in a plot:
 
 .blue[`r icons::fontawesome("plus")`] to add a layer
 
-</br>
 
-ggplot(data = capacity_ae) .blue[`r icons::fontawesome("plus")`] 
-</br> .blue[geom_point](aes(x = dcubicles, y = dwait)) .blue[`r icons::fontawesome("plus")`] 
-</br> .blue[geom_smooth](aes(x = dcubicles, y = dwait))
 
-</br>
+ggplot(data = capacity_ae) .blue[`r icons::fontawesome("plus")`]   
+ .blue[geom_point](aes(x = dcubicles, y = dwait)) .blue[`r icons::fontawesome("plus")`]   
+ .blue[geom_smooth](aes(x = dcubicles, y = dwait))  
+
+
 
 .blue[then specify another geom...]
   
@@ -524,9 +524,9 @@ ggplot(data = capacity_ae) +
 
 ```
 
-</br> Add a geom_smooth layer (to help identify patterns)
+ Add a geom_smooth layer (to help identify patterns)  
 
-</br> Hint: Don't forget the .blue[+] and aes() values in the new layer
+ Hint: Don't forget the .blue[+] and aes() values in the new layer  
 
 ---
 
@@ -583,11 +583,11 @@ class: center, middle
 
 # Hypothesis
 
-</br> The two sites have seen staffing increases
+ The two sites have seen staffing increases  
 
-</br> We can map point .blue[colour] (aesthetic attribute) to the staff_increase variable to find out
+ We can map point .blue[colour] (aesthetic attribute) to the staff_increase variable to find out  
 
-</br> We will add colour to the chart depending on the value of staff_increase (TRUE or FALSE, 1 or 0)
+ We will add colour to the chart depending on the value of staff_increase (TRUE or FALSE, 1 or 0)  
 
 ---
 
@@ -604,7 +604,7 @@ ggplot(data = capacity_ae) +
               method = "lm") 
 ```
 
-</br> We could have equally have chosen size or shape but these make graphic less clear
+ We could have equally have chosen size or shape but these make graphic less clear
 
 ---
 
@@ -630,7 +630,7 @@ ggplot(data = capacity_ae) +
               method = "lm") 
 ```
 
-</br> This works too because the colour is generically applied:
+ This works too because the colour is generically applied:
 
 ```{r}
 ggplot(data = capacity_ae) + 
@@ -666,7 +666,7 @@ ggplot(data = capacity_ae) +
   geom_smooth(aes(dcubicles, dwait)) #<<
 ```
 
-</br> Move the aes to the "global":
+ Move the aes to the "global":
 
 ```{r}
 ggplot(data = capacity_ae, aes(dcubicles, dwait)) +
@@ -704,8 +704,8 @@ class: center, middle
 
 # Demonstrating geom charts
 
-(note: these are simple,
-</br> unpolished graphics)
+(note: these are simple,  
+ unpolished graphics)
 
 ---
 
@@ -730,7 +730,7 @@ ggplot(data = capacity_ae) +
                  binwidth = 10)
 ```
 
-</br> With "bins" set so more uniformed in spread:
+ With "bins" set so more uniformed in spread:
 
 
 ---
@@ -747,7 +747,7 @@ ggplot(data = capacity_ae) +
 
 --
 
-</br> Reorder site __by__ attendances
+ Reorder site __by__ attendances
 
 ```{r}
 ggplot(data = capacity_ae) +
@@ -804,15 +804,15 @@ ggplot(data = capacity_ae) +
          height = 10, width = 8) #<<
 ```
 
-</br> By default saves a plot in the same dimensions as plot window.
+ By default saves a plot in the same dimensions as plot window.  
 
 In future, you'll wish to add height, width and "units" arguments to specify plot dimensions.
 
 ---
-#### This work is licensed as
-</br> Creative Commons
-</br> Attribution
-</br> ShareAlike 4.0
-</br> International
-</br> To view a copy of this license, visit
-</br> https://creativecommons.org/licenses/by/4.0/
+#### This work is licensed as  
+ Creative Commons  
+ Attribution  
+ ShareAlike 4.0  
+ International  
+ To view a copy of this license, visit  
+ https://creativecommons.org/licenses/by/4.0/  


### PR DESCRIPTION
## This PR closes the following issue:
closes #54 

## Changes made:
- Removed unnecessary `<br>` tags from slides and add two spaces at the end of the text.